### PR TITLE
Fixes a typo "degress" to "degrees" in example.py & README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Just execute it and you will get the temperatures in Kelvin, Degrees Celsius and
 
       $ python example.py
       Kelvin: 295.275000
-      Degress Celsius: 23.125000
-      Degress Fahrenheit: 73.625000
+      Degrees Celsius: 23.125000
+      Degrees Fahrenheit: 73.625000
       =====================================
       Kelvin: 296.025000
-      Degress Celsius: 23.875000
-      Degress Fahrenheit: 74.975000
+      Degrees Celsius: 23.875000
+      Degrees Fahrenheit: 74.975000
       =====================================
       ...
 

--- a/tests/example.py
+++ b/tests/example.py
@@ -10,8 +10,8 @@ def main():
     while True:
         temperatures = sensor.get_temperatures([DS18B20.DEGREES_C, DS18B20.DEGREES_F, DS18B20.KELVIN])
         print("Kelvin: %f" % temperatures[2])
-        print("Degress Celsius: %f" % temperatures[0])
-        print("Degress Fahrenheit: %f" % temperatures[1])
+        print("Degrees Celsius: %f" % temperatures[0])
+        print("Degrees Fahrenheit: %f" % temperatures[1])
         print("=====================================")
         sleep(1)
 


### PR DESCRIPTION
It's a minor issue that I came across which bugged me. I figured I'd send in a quick PR as it would only take a few minutes.

All this change does is modify a string in both README.md and test.py, both which don't directly affect the program.
