### PR TITLE
Updated Rasbian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This possibility is supported on all distributions:
 If you are using the `w1thermsensor` module on a Rasperry Pi running Raspbian you can install it from the official repository:
 
 ```bash
+sudo apt-get install python3-setuptools
 sudo apt-get install python3-w1thermsensor
 ```
 


### PR DESCRIPTION
I installed per your Rasbian instructions but got this error `ImportError: No module named 'pkg_resources'` when running `w1thermsensor ls`. I installed python3-setuptools to resolve it.