### PR TITLE
Fix cli precision command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ $ w1thermsensor get --hwid 00000588806a --type DS18B20 --precision 11
 ### Change temperature read precision and write to EEPROM
 
 ```
-$ w1thermsensor precision 1 10
+$ w1thermsensor precision 10 1
 $ w1thermsensor precision --hwid 00000588806a --type DS18B20 11
 ```
 


### PR DESCRIPTION
Just played around on Raspbian (installed python3-w1thermsensor using apt) and stumbled upon it. The hint messages were a bit strange too, so maybe the README was actually right but the argument parser is screwed up?