### PR TITLE
Parse raw bytes to get max. resolution

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,8 +11,8 @@ import pytest
 from w1thermsensor import W1ThermSensor
 
 #: Holds sample contents for a ready and not ready sensor
-W1_FILE = """9e 01 4b 46 7f ff 02 10 56 : crc=56 {ready}
-9e 01 4b 46 7f ff 02 10 56 t={temperature}
+W1_FILE = """{lsb:x} {msb:x} 4b 46 {config:x} ff 02 10 56 : crc=56 {ready}
+{lsb:x} {msb:x} 4b 46 {config:x} ff 02 10 56 t={temperature}
 """
 
 
@@ -50,6 +50,9 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
         for sensor_conf in request.param:
             sensor_type = sensor_conf.get("type", W1ThermSensor.THERM_SENSOR_DS18B20)
             sensor_id = sensor_conf.get("id") or get_random_sensor_id()
+            sensor_msb = sensor_conf.get("msb", 0x01)
+            sensor_lsb = sensor_conf.get("lsb", 0x40)
+            sensor_config_bit = sensor_conf.get("config", 0x7f)
             sensor_temperature = sensor_conf.get("temperature", 20)
             sensor_ready = sensor_conf.get("ready", True)
 
@@ -59,9 +62,13 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
 
             sensor_file = sensor_dir.join(W1ThermSensor.SLAVE_FILE)
             sensor_file_content = W1_FILE.format(
+                msb=sensor_msb,
+                lsb=sensor_lsb,
                 temperature=sensor_temperature * 1000.0,
+                config=sensor_config_bit,
                 ready="YES" if sensor_ready else "NO",
             )
+            print(sensor_file_content)
             sensor_file.write(sensor_file_content)
 
             sensors_.append(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -50,10 +50,11 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
         for sensor_conf in request.param:
             sensor_type = sensor_conf.get("type", W1ThermSensor.THERM_SENSOR_DS18B20)
             sensor_id = sensor_conf.get("id") or get_random_sensor_id()
-            sensor_msb = sensor_conf.get("msb", 0x01)
-            sensor_lsb = sensor_conf.get("lsb", 0x40)
-            sensor_config_bit = sensor_conf.get("config", 0x7f)
             sensor_temperature = sensor_conf.get("temperature", 20)
+            sensor_counts = int(sensor_temperature * 16.0)
+            sensor_msb = sensor_conf.get("msb", sensor_counts >> 8)
+            sensor_lsb = sensor_conf.get("lsb", sensor_counts & 0xff)
+            sensor_config_bit = sensor_conf.get("config", 0x7f)
             sensor_ready = sensor_conf.get("ready", True)
 
             sensor_dir = kernel_module_dir.mkdir(
@@ -68,7 +69,6 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
                 config=sensor_config_bit,
                 ready="YES" if sensor_ready else "NO",
             )
-            print(sensor_file_content)
             sensor_file.write(sensor_file_content)
 
             sensors_.append(

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -196,10 +196,10 @@ def test_init_sensor_by_type_and_id(sensors, sensor_specs):
 @pytest.mark.parametrize(
     "sensors, unit, expected_temperature",
     [
-        (({"temperature": 20.0},), W1ThermSensor.DEGREES_C, 20.0),
-        (({"temperature": 42.21},), W1ThermSensor.DEGREES_C, 42.21),
-        (({"temperature": 42.21},), W1ThermSensor.DEGREES_F, 107.978),
-        (({"temperature": 42.21},), W1ThermSensor.KELVIN, 315.36),
+        (({"msb": 0x01, "lsb": 0x40, "temperature": 20.0},), W1ThermSensor.DEGREES_C, 20.0),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "celsius", 25.0625),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "fahrenheit", 77.1125),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "kelvin", 298.2125),
     ],
     indirect=["sensors"],
 )
@@ -216,9 +216,9 @@ def test_get_temperature_for_different_units(sensors, unit, expected_temperature
 @pytest.mark.parametrize(
     "sensors, unit, expected_temperature",
     [
-        (({"temperature": 42.21},), "celsius", 42.21),
-        (({"temperature": 42.21},), "fahrenheit", 107.978),
-        (({"temperature": 42.21},), "kelvin", 315.36),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "celsius", 25.0625),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "fahrenheit", 77.1125),
+        (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "kelvin", 298.2125),
     ],
     indirect=["sensors"],
 )
@@ -237,21 +237,24 @@ def test_get_temperature_for_different_units_by_name(
 @pytest.mark.parametrize(
     "sensors, units, expected_temperatures",
     [
-        (({"temperature": 20.0},), [W1ThermSensor.DEGREES_C], [20.0]),
         (
-            ({"temperature": 42.21},),
+            ({"msb": 0x01, "lsb": 0x40, "temperature": 20.0},),
+            [W1ThermSensor.DEGREES_C],
+            [20.0]),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
             [W1ThermSensor.DEGREES_C, W1ThermSensor.DEGREES_F],
-            [42.21, 107.978],
+            [25.0625, 77.1125],
         ),
         (
-            ({"temperature": 42.21},),
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.06251},),
             [W1ThermSensor.DEGREES_F, W1ThermSensor.KELVIN],
-            [107.978, 315.36],
+            [77.1125, 298.2125],
         ),
         (
-            ({"temperature": 42.21},),
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
             [W1ThermSensor.DEGREES_C, W1ThermSensor.DEGREES_F, W1ThermSensor.KELVIN],
-            [42.21, 107.978, 315.36],
+            [25.0625, 77.1125, 298.2125],
         ),
     ],
     indirect=["sensors"],
@@ -391,7 +394,7 @@ def test_sensor_disconnect_after_init(sensors):
 
     # when & then
     with pytest.raises(NoSensorFoundError, message=expected_error_msg):
-        sensor.raw_sensor_value
+        sensor.raw_sensor_temp
 
 
 @pytest.mark.parametrize(
@@ -532,7 +535,7 @@ def test_kernel_module_load_error(monkeypatch):
         load_kernel_modules()
 
 
-@pytest.mark.parametrize("sensors", [(({"temperature": 85.00},))], indirect=["sensors"])
+@pytest.mark.parametrize("sensors", [(({"msb": 0x05, "lsb": 0x50, "temperature": 85.00},))], indirect=["sensors"])
 def test_handling_reset_value(sensors):
     """Test handling the reset value from a sensor reading"""
     # given

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -527,6 +527,26 @@ def test_setting_invalid_precision(sensors, precision):
         sensor.set_precision(precision)
 
 
+@pytest.mark.parametrize(
+    "sensors, expected_precision",
+    [
+        (({"config": 0x1f},), 9),
+        (({"config": 0x3f},), 10),
+        (({"config": 0x5f},), 11),
+        (({"config": 0x7f},), 12),
+    ],
+    indirect=["sensors"],
+)
+def test_get_precision(sensors, expected_precision):
+    """Test getting the sensor precison"""
+    # given
+    sensor = W1ThermSensor()
+    # when
+    precision = sensor.get_precision()
+    # then
+    assert precision == pytest.approx(expected_precision)
+
+
 def test_kernel_module_load_error(monkeypatch):
     """Test exception if kernel modules cannot be loaded"""
     # given

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -559,7 +559,11 @@ def test_kernel_module_load_error(monkeypatch):
         load_kernel_modules()
 
 
-@pytest.mark.parametrize("sensors", [(({"msb": 0x05, "lsb": 0x50, "temperature": 85.00},))], indirect=["sensors"])
+@pytest.mark.parametrize(
+    "sensors",
+    [(({"msb": 0x05, "lsb": 0x50, "temperature": 85.00},))],
+    indirect=["sensors"]
+)
 def test_handling_reset_value(sensors):
     """Test handling the reset value from a sensor reading"""
     # given

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -197,9 +197,13 @@ def test_init_sensor_by_type_and_id(sensors, sensor_specs):
     "sensors, unit, expected_temperature",
     [
         (({"msb": 0x01, "lsb": 0x40, "temperature": 20.0},), W1ThermSensor.DEGREES_C, 20.0),
+        (({"msb": 0xff, "lsb": 0xf8, "temperature": -0.5},), W1ThermSensor.DEGREES_C, -0.5),
+        (({"msb": 0xFC, "lsb": 0x90, "temperature": -55},), W1ThermSensor.DEGREES_C, -55),
         (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "celsius", 25.0625),
         (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "fahrenheit", 77.1125),
+        (({"msb": 0xFC, "lsb": 0x90, "temperature": -55},), "fahrenheit", -67),
         (({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},), "kelvin", 298.2125),
+        (({"msb": 0xFC, "lsb": 0x90, "temperature": -55},), "kelvin", 218.15),
     ],
     indirect=["sensors"],
 )

--- a/w1thermsensor/core.py
+++ b/w1thermsensor/core.py
@@ -216,13 +216,14 @@ class W1ThermSensor(object):
             raise SensorNotReadyError(self)
 
         return data
-    
+
     @property
     def raw_sensor_count(self):
         """
             Returns the raw integer ADC count from the sensor
 
-            Note: Must be divided depending on the max. sensor resolution to get floating point celsius
+            Note: Must be divided depending on the max. sensor resolution
+            to get floating point celsius
 
             :returns: the raw value from the sensor ADC
             :rtype: int
@@ -238,11 +239,10 @@ class W1ThermSensor(object):
         int16 = int(bytes[1] + bytes[0], 16)
 
         # check first signing bit
-        if int16 >> 15 == 0: 
-            return int16 # positive values need no processing
+        if int16 >> 15 == 0:
+            return int16  # positive values need no processing
         else:
-            return int16 - (1 << 16) # substract 2^16 to get correct negative value
-
+            return int16 - (1 << 16)  # substract 2^16 to get correct negative value
 
     @property
     def raw_sensor_temp(self):
@@ -258,7 +258,6 @@ class W1ThermSensor(object):
 
         # return the value in millicelsius
         return float(self.raw_sensor_strings[1].split("=")[1])
-
 
     @classmethod
     def _get_unit_factor(cls, unit):
@@ -334,10 +333,10 @@ class W1ThermSensor(object):
             :returns: sensor resolution from 9-12 bits
             :rtype: int
         """
-        config_str = self.raw_sensor_strings[1].split()[4] # Byte 5 is the config register
-        bit_base = int(config_str, 16) >> 5 # Bit 5-6 contains the resolution, cut off the rest
-        return bit_base + 9 # min. is 9 bits
-  
+        config_str = self.raw_sensor_strings[1].split()[4]  # Byte 5 is the config register
+        bit_base = int(config_str, 16) >> 5  # Bit 5-6 contains the resolution, cut off the rest
+        return bit_base + 9  # min. is 9 bits
+
     def set_precision(self, precision, persist=False):
         """
             Set the precision of the sensor for the next readings.

--- a/w1thermsensor/core.py
+++ b/w1thermsensor/core.py
@@ -299,6 +299,11 @@ class W1ThermSensor(object):
         sensor_value = self.get_temperature(self.DEGREES_C)
         return [self._get_unit_factor(unit)(sensor_value) for unit in units]
 
+    def get_precision(self):
+        config_str = self.raw_sensor_strings[1].split()[4] # Byte 5 is the config register
+        bit_base = int(config_str, 16) >> 5 # Bit 5-6 contain the resolution, cut off the rest
+        return bit_base + 9 # min. is 9 bits
+        
     def set_precision(self, precision, persist=False):
         """
             Set the precision of the sensor for the next readings.


### PR DESCRIPTION
On full 12 bit resolution the steps are 1/16 °C = 0.0625 °C, that is a problem with the milli celsius output calculated from the kernel module. It will simply cut off the last digit and therefore distort the output. For example 19.8125 becomes just 19.812.
This PR changes the data source to the raw bytes and calculates the temperature in the module itself, to preserve full precision on 12 bit.

The calculation works on the following types, all with the same 9-12bit memory layout:
https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf
https://datasheets.maximintegrated.com/en/ds/DS1822.pdf
https://datasheets.maximintegrated.com/en/ds/DS1825.pdf
https://datasheets.maximintegrated.com/en/ds/DS28EA00.pdf
These have all the same 85 °C reset value, that check is then also enabled on them.

The DS18S20 is different, provides only 9bit in the usual registers, but it is possible to get some more data from other registers:
https://datasheets.maximintegrated.com/en/ds/DS18S20.pdf
The MAX31850 has a bit different register ordering, otherwise similar to the first 4 types:
https://cdn-shop.adafruit.com/datasheets/MAX31850-MAX31851.pdf
So for the DS18S20 and MAX31850 it uses still the old millicelsius method.

Also i have added a `get_precision` method, which reads and parses the currently set resolution from the sensor memory. 
In addition it would be pretty easy now to add read functionality for the user data/alarm registers, but i think that is not to relevant for most users.