### PR TITLE
Add support for offsetting temperature readings

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -357,6 +357,7 @@ def test_get_temperature_of_sensor_json(sensors):
     sensor = sensors[0]
     expected_json_output = {
         "hwid": sensor["id"],
+        "offset": 0.0,
         "type": W1ThermSensor.TYPE_NAMES[sensor["type"]],
         "temperature": sensor["temperature"],
         "unit": "celsius",
@@ -414,6 +415,7 @@ def test_get_temperature_of_sensor_by_hwid(sensors, hwid):
     sensor = [s for s in sensors if s["id"] == hwid][0]
     expected_json_output = {
         "hwid": sensor["id"],
+        "offset": 0.0,
         "type": W1ThermSensor.TYPE_NAMES[sensor["type"]],
         "temperature": sensor["temperature"],
         "unit": "celsius",
@@ -445,6 +447,32 @@ def test_get_temperature_of_sensor_with_precision(sensors, mocker):
     sensor = sensors[0]
     expected_output = "Sensor {0} measured temperature: {1} celsius".format(
         sensor["id"], sensor["temperature"]
+    )
+    assert expected_output in result.output
+
+
+@pytest.mark.parametrize(
+    "sensors, offset, expected_temperature",
+    [
+        (({"type": W1ThermSensor.THERM_SENSOR_DS18B20, "temperature": 20.0},), 10, 30.0,),
+        (({"type": W1ThermSensor.THERM_SENSOR_DS18S20, "temperature": -8.0},), 10, 2.0,),
+    ],
+    indirect=["sensors"],
+)
+def test_get_temperature_of_sensor_with_offset(
+        sensors, offset, expected_temperature, mocker
+):
+    """Test getting temperature of a single sensor with an offset"""
+    # given
+    runner = CliRunner()
+    # when
+    result = runner.invoke(cli, ["get", "--offset", offset])
+    # then
+    assert result.exit_code == 0
+    # expect the single sensor to be reported correctly, with offset applied
+    sensor = sensors[0]
+    expected_output = "Sensor {0} measured temperature: {1} celsius".format(
+        sensor["id"], expected_temperature
     )
     assert expected_output in result.output
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -298,9 +298,8 @@ def test_get_temperature_for_different_units_by_name_with_offsets(
 ):
     """Test getting offset sensor values for different units"""
     # given
-    sensor = W1ThermSensor()
+    sensor = W1ThermSensor(W1ThermSensor.THERM_SENSOR_DS18B20, 0, offset, offset_unit)
     # when
-    sensor.set_offset(offset, offset_unit)
     temperature = sensor.get_temperature(result_unit)
     gotten_offset = sensor.get_offset(result_unit)
     # then

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -251,6 +251,64 @@ def test_get_temperature_for_different_units_by_name(
 
 
 @pytest.mark.parametrize(
+    "sensors, result_unit, offset_unit, offset, expected_offset, expected_temperature",
+    [
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "celsius", "celsius", 10, 10, 35.0625
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "fahrenheit", "celsius", 10, 18, 95.1125
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "kelvin", "celsius", 10, 10, 308.2125
+        ),
+
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "celsius", "fahrenheit", 18, 10, 35.0625),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "fahrenheit", "fahrenheit", 18, 18, 95.1125
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "kelvin", "fahrenheit", 18, 10, 308.2125
+        ),
+
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "celsius", "kelvin", 10, 10, 35.0625
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "fahrenheit", "kelvin", 10, 18, 95.1125
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            "kelvin", "kelvin", 10, 10, 308.2125
+        ),
+    ],
+    indirect=["sensors"],
+)
+def test_get_temperature_for_different_units_by_name_with_offsets(
+    sensors, result_unit, offset_unit, offset, expected_offset, expected_temperature
+):
+    """Test getting offset sensor values for different units"""
+    # given
+    sensor = W1ThermSensor()
+    # when
+    sensor.set_offset(offset, offset_unit)
+    temperature = sensor.get_temperature(result_unit)
+    gotten_offset = sensor.get_offset(result_unit)
+    # then
+    assert temperature == pytest.approx(expected_temperature)
+    assert gotten_offset == expected_offset
+
+
+@pytest.mark.parametrize(
     "sensors, units, expected_temperatures",
     [
         (
@@ -281,6 +339,49 @@ def test_get_temperature_in_multiple_units(sensors, units, expected_temperatures
     # given
     sensor = W1ThermSensor()
     # when
+    temperatures = sensor.get_temperatures(units)
+    # then
+    assert temperatures == pytest.approx(expected_temperatures)
+
+
+@pytest.mark.parametrize(
+    "sensors, units, offset, expected_temperatures",
+    [
+        (
+            ({"msb": 0x01, "lsb": 0x40, "temperature": 20.0},),
+            [W1ThermSensor.DEGREES_C],
+            -10,
+            [10.0],
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            [W1ThermSensor.DEGREES_C, W1ThermSensor.DEGREES_F],
+            10,
+            [35.0625, 95.1125],
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.06251},),
+            [W1ThermSensor.DEGREES_F, W1ThermSensor.KELVIN],
+            10,
+            [95.1125, 308.2125],
+        ),
+        (
+            ({"msb": 0x01, "lsb": 0x91, "temperature": 25.0625},),
+            [W1ThermSensor.DEGREES_C, W1ThermSensor.DEGREES_F, W1ThermSensor.KELVIN],
+            10,
+            [35.0625, 95.1125, 308.2125],
+        ),
+    ],
+    indirect=["sensors"],
+)
+def test_get_temperature_in_multiple_units_with_offsets(
+        sensors, units, offset, expected_temperatures
+):
+    """Test getting a sensor temperature in multiple units"""
+    # given
+    sensor = W1ThermSensor()
+    # when
+    sensor.set_offset(offset)
     temperatures = sensor.get_temperatures(units)
     # then
     assert temperatures == pytest.approx(expected_temperatures)

--- a/w1thermsensor/cli.py
+++ b/w1thermsensor/cli.py
@@ -172,7 +172,14 @@ def all(types, unit, precision, as_json):  # pylint: disable=redefined-builtin
 @click.option(
     "-j", "--json", "as_json", flag_value=True, help="Output result in JSON format"
 )
-def get(id_, hwid, type_, unit, precision, as_json):
+@click.option(
+    "-o",
+    "--offset",
+    default=0.0,
+    type=click.FLOAT,
+    help="Offset the temperature reading by the given offset temperature.",
+)
+def get(id_, hwid, type_, unit, precision, as_json, offset):
     """Get temperature of a specific sensor"""
     if id_ and (hwid or type_):
         raise click.BadOptionUsage(
@@ -193,11 +200,15 @@ def get(id_, hwid, type_, unit, precision, as_json):
     if precision:
         sensor.set_precision(precision, persist=False)
 
+    if offset:
+        sensor.set_offset(offset, unit)
+
     temperature = sensor.get_temperature(unit)
 
     if as_json:
         data = {
             "hwid": sensor.id,
+            "offset": offset,
             "type": sensor.type_name,
             "temperature": temperature,
             "unit": unit,


### PR DESCRIPTION
A deficient temperature sensor may report an incorrect temperature.
set_offset allows adding or subtracting a fixed value from readings of a
sensor. This allows calibration of deficient sensors.