### PR TITLE
Remove pypy-5.3.1 in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
     - '3.6'
     - '3.7-dev'
     - 'pypy'
-    - 'pypy-5.3.1'
 
 services:
     - docker


### PR DESCRIPTION
Since the 'pypy' python version is still specified Travis will still
build for the latest pypy available (currently 7.1.1).

This fixes the build error in #68 