### PR TITLE
Include LICENSE in the sdist tarball

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Timo Furrer
+Copyright (c) 2015-2020 Timo Furrer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include *.md
 include *.rst
 include *.txt


### PR DESCRIPTION
Hi,

By including the LICENSE file in the sdist tarball/release, it will be much easier to write a BitBake recipe for w1thermsensor, so that it can be included in meta-openembedded (I plan to submit this soon).

I've also updated the license years.