### PR TITLE
setup.py: Make click dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ After that, don't forget to reboot.
 
 ### From PIP
 
-This possibility is supported on all distributions:
+To install the W1Thermsensor python module, this possibility is supported on all distributions:
 
     pip install w1thermsensor
+
+The `w1thermsensor` command has additional dependencies. In order to ensure `w1thermsensor` works properly, also install additional dependencies using the following command:
+
+    pip install "w1thermsensor[CLI]"
 
 *Note: maybe root privileges are required*
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ if sys.argv[-1] == "publish":
     os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
-required = ["click"]
-
 
 class UploadCommand(Command):
     """Support setup.py upload."""
@@ -82,7 +80,7 @@ setup_args = dict(
     url="http://github.com/timofurrer/w1thermsensor",
     download_url="http://github.com/timofurrer/w1thermsensor",
     packages=find_packages(exclude=["*tests*"]),
-    install_requires=required,
+    extras_require=dict(CLI="click>=7.0"),
     include_package_data=True,
     classifiers=(
         "Development Status :: 5 - Production/Stable",
@@ -105,7 +103,7 @@ setup_args = dict(
 
 if sys.version_info.major == 3:
     setup_args["entry_points"] = {
-        "console_scripts": ["w1thermsensor = w1thermsensor.cli:cli"]
+        "console_scripts": ["w1thermsensor = w1thermsensor.cli:cli [CLI]"]
     }
 
 setup(**setup_args)


### PR DESCRIPTION
This makes it easier to install only the python modules, and not the
w1thermsensor command line utility.

If there is only interest in the python modules, do the following:

    pip install w1thermsensor

If the w1thermsensor utility is invoked when the package has been
installed in this way, an informative error message is displayed,
notifying that click needs to be installed.

To ensure that the w1thermsor utility also works, specify additional
dependencies using [CLI], as such:

    pip install w1thermsensor[CLI]

Signed-off-by: Jonatan Pålsson <jonatan.p@gmail.com>