### PR TITLE
disconnected sensors still appear under /sys for a while but report w…

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,7 @@ W1_FILE_ZEROVALUES = """00 00 00 00 00 00 00 00 00 : crc=00 YES
 00 00 00 00 00 00 00 00 00 t=0
 """
 
+
 def get_random_sensor_id():
     """
     Return a valid random sensor id

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,7 +14,10 @@ from w1thermsensor import W1ThermSensor
 W1_FILE = """{lsb:x} {msb:x} 4b 46 {config:x} ff 02 10 56 : crc=56 {ready}
 {lsb:x} {msb:x} 4b 46 {config:x} ff 02 10 56 t={temperature}
 """
-
+#: Holds sample content for a partially disconnected sensor which only repors zero bytes
+W1_FILE_ZEROVALUES = """00 00 00 00 00 00 00 00 00 : crc=00 YES
+00 00 00 00 00 00 00 00 00 t=0
+"""
 
 def get_random_sensor_id():
     """
@@ -56,6 +59,7 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
             sensor_lsb = sensor_conf.get("lsb", sensor_counts & 0xFF)
             sensor_config_bit = sensor_conf.get("config", 0x7F)
             sensor_ready = sensor_conf.get("ready", True)
+            sensor_zerovalues = sensor_conf.get("zero_values", False)
 
             sensor_dir = kernel_module_dir.mkdir(
                 "{0}-{1}".format(hex(sensor_type)[2:], sensor_id)
@@ -68,7 +72,7 @@ def sensors(request, kernel_module_dir):  # pylint: disable=redefined-outer-name
                 temperature=sensor_temperature * 1000.0,
                 config=sensor_config_bit,
                 ready="YES" if sensor_ready else "NO",
-            )
+            ) if not sensor_zerovalues else W1_FILE_ZEROVALUES
             sensor_file.write(sensor_file_content)
 
             sensors_.append(

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -689,3 +689,17 @@ def test_handling_reset_value(sensors):
     # when & then
     with pytest.raises(ResetValueError, message=expected_error_msg):
         sensor.get_temperature()
+
+
+@pytest.mark.parametrize("sensors", [({"zero_values": True},)], indirect=["sensors"])
+def test_sensor_partially_disconnected(sensors):
+    """Test handling the partially disconnected sensor with wrong value"""
+    # given
+    sensor = W1ThermSensor()
+    expected_error_msg = "Sensor {} is not yet ready to read temperature".format(
+        sensor.id
+    )
+
+    # when & then
+    with pytest.raises(SensorNotReadyError, message=expected_error_msg):
+        sensor.get_temperature()

--- a/w1thermsensor/core.py
+++ b/w1thermsensor/core.py
@@ -240,7 +240,7 @@ class W1ThermSensor(object):
                 )
             )
 
-        if data[0].strip()[-3:] != "YES":
+        if data[0].strip()[-3:] != "YES" or "00 00 00 00 00 00 00 00 00" in data[0]:
             raise SensorNotReadyError(self)
 
         return data


### PR DESCRIPTION
…rong values
If sensors are disconnected they remain in the system for a while until they are detected as disconnected. If they are read in this time frame, they report wrong values of zeros only.