### PR TITLE
Fix missing docs/ dir

### DIFF
--- a/debian/python3-w1thermsensor.manpages
+++ b/debian/python3-w1thermsensor.manpages
@@ -2,4 +2,4 @@ docs/w1thermsensor.1
 docs/w1thermsensor-all.1
 docs/w1thermsensor-get.1
 docs/w1thermsensor-ls.1
-docs/w1thermsensor-precision.1
+docs/w1thermsensor-resolution.1

--- a/docs/w1thermsensor-all.1
+++ b/docs/w1thermsensor-all.1
@@ -1,0 +1,21 @@
+.TH "W1THERMSENSOR ALL" "1" "05-Jun-2017" "" "w1thermsensor all Manual"
+.SH NAME
+w1thermsensor\-all \- Get temperatures of all available sensors
+.SH SYNOPSIS
+.B w1thermsensor all
+[OPTIONS]
+.SH DESCRIPTION
+Get temperatures of all available sensors
+.SH OPTIONS
+.TP
+\fB\-t,\fP \-\-type [DS18S20|DS1822|DS18B20|MAX31850K|DS28EA00]
+Show only sensor of this type
+.TP
+\fB\-u,\fP \-\-unit [celsius|fahrenheit|kelvin]
+The unit of the temperature. Defaults to Celsius
+.TP
+\fB\-p,\fP \-\-resolution INTEGER RANGE
+use the given resolution for this read
+.TP
+\fB\-j,\fP \-\-json
+Output result in JSON format

--- a/docs/w1thermsensor-get.1
+++ b/docs/w1thermsensor-get.1
@@ -1,0 +1,24 @@
+.TH "W1THERMSENSOR GET" "1" "05-Jun-2017" "" "w1thermsensor get Manual"
+.SH NAME
+w1thermsensor\-get \- Get temperature of a specific sensor
+.SH SYNOPSIS
+.B w1thermsensor get
+[OPTIONS] id
+.SH DESCRIPTION
+Get temperature of a specific sensor
+.SH OPTIONS
+.TP
+\fB\-h,\fP \-\-hwid TEXT
+The hardware id of the sensor
+.TP
+\fB\-t,\fP \-\-type [DS18S20|DS1822|DS18B20|MAX31850K|DS28EA00]
+The type of the sensor
+.TP
+\fB\-u,\fP \-\-unit [celsius|fahrenheit|kelvin]
+The unit of the temperature. Defaults to Celsius
+.TP
+\fB\-p,\fP \-\-resolution INTEGER RANGE
+use the given resolution for this read
+.TP
+\fB\-j,\fP \-\-json
+Output result in JSON format

--- a/docs/w1thermsensor-ls.1
+++ b/docs/w1thermsensor-ls.1
@@ -1,0 +1,15 @@
+.TH "W1THERMSENSOR LS" "1" "05-Jun-2017" "" "w1thermsensor ls Manual"
+.SH NAME
+w1thermsensor\-ls \- List all available sensors
+.SH SYNOPSIS
+.B w1thermsensor ls
+[OPTIONS]
+.SH DESCRIPTION
+List all available sensors
+.SH OPTIONS
+.TP
+\fB\-t,\fP \-\-type [DS18S20|DS1822|DS18B20|MAX31850K|DS28EA00]
+Show only sensor of this type
+.TP
+\fB\-j,\fP \-\-json
+Output result in JSON format

--- a/docs/w1thermsensor-resolution.1
+++ b/docs/w1thermsensor-resolution.1
@@ -1,0 +1,15 @@
+.TH "W1THERMSENSOR RESOLUTION" "1" "05-Jun-2017" "" "w1thermsensor resolution Manual"
+.SH NAME
+w1thermsensor\-resolution \- Change the resolution for the sensor and...
+.SH SYNOPSIS
+.B w1thermsensor resolution
+[OPTIONS] RESOLUTION id
+.SH DESCRIPTION
+Change the resolution for the sensor and persist it in the sensor's EEPROM
+.SH OPTIONS
+.TP
+\fB\-h,\fP \-\-hwid TEXT
+The hardware id of the sensor
+.TP
+\fB\-t,\fP \-\-type [DS18S20|DS1822|DS18B20|MAX31850K|DS28EA00]
+The type of the sensor

--- a/docs/w1thermsensor.1
+++ b/docs/w1thermsensor.1
@@ -1,0 +1,36 @@
+.TH "W1THERMSENSOR" "1" "05-Jun-2017" "" "w1thermsensor Manual"
+.SH NAME
+w1thermsensor \- Get the temperature from your connected w1...
+.SH SYNOPSIS
+.B w1thermsensor
+[OPTIONS] COMMAND [ARGS]...
+.SH DESCRIPTION
+Get the temperature from your connected w1 therm sensors
+
+
+Available sensors types are:
+  - DS18S20
+  - DS1822
+  - DS18B20
+  - DS28EA00
+  - DS1825/MAX31850K
+.SH COMMANDS
+.PP
+\fBls\fP
+  List all available sensors
+  See \fBw1thermsensor-ls(1)\fP for full documentation on the \fBls\fP command.
+
+.PP
+\fBall\fP
+  Get temperatures of all available sensors
+  See \fBw1thermsensor-all(1)\fP for full documentation on the \fBall\fP command.
+
+.PP
+\fBget\fP
+  Get temperature of a specific sensor
+  See \fBw1thermsensor-get(1)\fP for full documentation on the \fBget\fP command.
+
+.PP
+\fBresolution\fP
+  Change the resolution for the sensor and...
+  See \fBw1thermsensor-resolution(1)\fP for full documentation on the \fBresolution\fP command.


### PR DESCRIPTION
The docs/ dir seems to have been removed from master in commit:

  97b832df5fa0c7b8ee24408e6b5147732634444e Remove precision APIs

This commit replaces the docs/ dir with all references to
"precision" changed to "resolution".