### PR TITLE
Add bulk read temperature method

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,33 @@ for sensor in W1ThermSensor.get_available_sensors([Sensor.DS18B20]):
     print("Sensor %s has temperature %.2f" % (sensor.id, sensor.get_temperature()))
 ```
 
+### Multiple sensors using bulk conversion
+
+Using bulk conversion method returns a list of available sensors in a bus, with property `temperature`. By default, uses temperature in Celsius, if `Unit` parameter is not specified. Otherwise, use `w1thermsensor.Unit` to convert to your desired unit.
+
+This method speeds up the process of reading all sensors in the bus to the single sensor conversion time.
+
+E.g. Having 3 sensors in the bus with a 12bit resolution will result in `~750ms * 3 sensors = ~2,3s` using traditional method above. With the bulk conversion it will last around `~750ms`  
+
+*Note: Bulk conversion requires root privileges or permissions change to `w1_master*` path*
+
+*Method do not support sensor calibration or offset configuration!*
+
+`*w1_master` path is: 
+- (symbolic link) - `/sys/bus/w1/devices/w1_bus_master1/therm_bulk_read`
+- (destination link) - `/sys/devices/w1_bus_master1/therm_bulk_read`
+
+If you don't want to run your script as a root - do `chmod +w` or `chown` to a user executing your python script to the one of the paths above.
+
+```python
+from w1thermsensor import W1ThermSensor, Unit
+
+for sensor in W1ThermSensor.get_bulk_temperature():
+            # W1ThermSensor.bulk_read(Unit.KELVIN)
+            # W1ThermSensor.bulk_read(Unit.DEGREES_F)
+    print(f"Sensor: {sensor.id}, temp: {sensor.temperature}")
+```
+
 ### Set sensor resolution
 
 Some w1 therm sensors support changing the resolution for the temperature reads.

--- a/src/w1thermsensor/errors.py
+++ b/src/w1thermsensor/errors.py
@@ -83,3 +83,21 @@ class InvalidCalibrationDataError(W1ThermSensorError):
         super().__init__(
             "Calibration data {} is invalid: {}.".format(message, calibration_data)
         )
+
+
+class BulkConversionStatusError(W1ThermSensorError):
+    """Exception when the conversion status for a bulk action fails"""
+
+    def __init__(self, status, message):
+        super().__init__(
+            f"Bulk conversion status indicates failure. Status: {status}\nMessage: {message}"
+        )
+
+
+class BulkTemperatureDataError(W1ThermSensorError):
+    """Exception when the bulk conversion temperatures returns empty data"""
+
+    def __init__(self, sensor_id):
+        super().__init__(
+            f"Bulk conversion temperature did NOT return data. Sensor ID: {sensor_id}"
+        )


### PR DESCRIPTION
Hi,
I've created a synchronous method to implement bulk read temperature operation.
It increases efficiency to get all sensors' temperature in time of a longest single sensor cycle.
Tested with 5 sensors with a 12bit resolution, I've reduced the time from: 
`4.016239s` using traditional `get_temperature()` with a for loop,
 to 
`0.897658s` using bulk read capability.
Let me know if I'm missing something.

Solves: #115 